### PR TITLE
fix: safeguard 'gum' dependency and enhance uninstall error reporting

### DIFF
--- a/omarchy-cleaner.sh
+++ b/omarchy-cleaner.sh
@@ -1,5 +1,59 @@
 #!/bin/bash
 
+# --- Gum Dependency Check ---
+# This script requires 'gum' for its interactive UI.
+# This section checks if gum is installed and offers to install it if not found.
+if ! command -v gum &>/dev/null; then
+    # Use standard echo and read for prompts since gum is not available.
+    echo -e "\033[1;35m--- Omarchy Cleaner ---\033[0m"
+    echo -e "\033[1;33m⚠️  Dependency 'gum' not found.\033[0m"
+    echo "This script uses 'gum' to create its interactive user interface."
+    echo ""
+    
+    read -p "Would you like to install it now? [Y/n] " choice
+    
+    case "$choice" in
+      [Yy]*|"") # Default to Yes
+        echo ""
+        echo "⏳ Trying to install gum..."
+        if command -v pacman &>/dev/null; then
+            if sudo pacman -S --noconfirm gum; then
+                echo -e "\033[1;32m✅ Gum installed successfully via pacman.\033[0m"
+            else
+                echo -e "\033[1;31m❌ Failed to install gum using pacman.\033[0m Please try installing it manually."
+                exit 1
+            fi
+        elif command -v yay &>/dev/null; then
+            if yay -S --noconfirm gum; then
+                echo -e "\033[1;32m✅ Gum installed successfully via yay.\033[0m"
+            else
+                echo -e "\033[1;31m❌ Failed to install gum using yay.\033[0m Please try installing it manually."
+                exit 1
+            fi
+        else
+            echo -e "\033[1;31m❌ Could not find 'pacman' or 'yay'.\033[0m"
+            echo "Please install 'gum' manually and run the script again."
+            exit 1
+        fi
+        
+        # Verify installation
+        if ! command -v gum &>/dev/null; then
+            echo -e "\033[1;31m❌ Gum installation seems to have failed. Exiting.\033[0m"
+            exit 1
+        else
+            echo "Setup complete. Relaunching script..."
+            # Re-execute the script to use gum from the start
+            exec "$0" "$@"
+        fi
+        ;;
+      *)
+        echo ""
+        echo -e "\033[1;31m❌ 'gum' is required to run this script. Exiting.\033[0m"
+        exit 1
+        ;;
+    esac
+fi
+
 # Omarchy Cleaner - Remove unwanted default applications from Omarchy
 # Enhanced with gum for a better TUI experience
 
@@ -28,7 +82,7 @@ DEFAULT_APPS=(
     "docker"
     "docker-buildx"
     "docker-compose"
-    
+
     # Uncomment to include in removal list
     # "asdcontrol-git"
     # "alacritty"
@@ -60,7 +114,6 @@ DEFAULT_APPS=(
     # "gnome-calculator"
     # "gnome-keyring"
     # "gnome-themes-extra"
-    # "gum"
     # "gvfs-mtp"
     # "gvfs-smb"
     # "hypridle"
@@ -203,15 +256,15 @@ get_installed_webapps() {
 find_app_bindings() {
     local app_name="$1"
     local bindings=()
-    
+
     if [[ ! -f "$BINDINGS_FILE" ]]; then
         echo ""
         return
     fi
-    
+
     # Convert app name to lowercase for case-insensitive matching
     local app_lower=$(echo "$app_name" | tr '[:upper:]' '[:lower:]')
-    
+
     # Define webapp URL patterns for known webapps
     local webapp_domains=""
     case "$app_lower" in
@@ -255,17 +308,17 @@ find_app_bindings() {
             webapp_domains="zoom.us|zoom.com"
             ;;
     esac
-    
+
     # Read the bindings file and find matching lines
     while IFS= read -r line; do
         # Skip comments and empty lines
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
         [[ -z "${line// }" ]] && continue
-        
+
         # Check if this is a bindd line
         if [[ "$line" =~ ^bindd[[:space:]]*= ]]; then
             local line_lower=$(echo "$line" | tr '[:upper:]' '[:lower:]')
-            
+
             # Check for app matches in various formats
             # Direct app name match (e.g., "spotify", "obsidian", "signal-desktop")
             if [[ "$line_lower" =~ uwsm[[:space:]]+app[[:space:]]+--[[:space:]]+$app_lower([[:space:]]|$) ]]; then
@@ -306,7 +359,7 @@ find_app_bindings() {
             fi
         fi
     done < "$BINDINGS_FILE"
-    
+
     # Return unique bindings
     printf '%s\n' "${bindings[@]}" | sort -u
 }
@@ -314,29 +367,29 @@ find_app_bindings() {
 # Function to remove bindings from the config file
 remove_bindings_from_file() {
     local bindings_to_remove=("$@")
-    
+
     if [[ ${#bindings_to_remove[@]} -eq 0 ]]; then
         return 0
     fi
-    
+
     if [[ ! -f "$BINDINGS_FILE" ]]; then
         gum log --level warn "Bindings file not found at $BINDINGS_FILE"
         return 1
     fi
-    
+
     # Create backup
     local backup_file="${BINDINGS_FILE}.backup.$(date +%Y%m%d_%H%M%S)"
     cp "$BINDINGS_FILE" "$backup_file"
     gum log --level info "Created backup: $backup_file"
-    
+
     # Create temporary file
     local temp_file=$(mktemp)
     local removed_count=0
-    
+
     # Process the file line by line
     while IFS= read -r line; do
         local should_remove=false
-        
+
         # Check if this line should be removed
         for binding in "${bindings_to_remove[@]}"; do
             if [[ "$line" == "$binding" ]]; then
@@ -345,16 +398,16 @@ remove_bindings_from_file() {
                 break
             fi
         done
-        
+
         # Write line to temp file if not removing
         if [[ "$should_remove" == false ]]; then
             echo "$line" >> "$temp_file"
         fi
     done < "$BINDINGS_FILE"
-    
+
     # Replace original file with temp file
     mv "$temp_file" "$BINDINGS_FILE"
-    
+
     gum log --level info "✓ Removed $removed_count keyboard binding(s)"
     return 0
 }
@@ -367,7 +420,7 @@ enhanced_select_packages() {
     local item_types=()
     local display_items=()
     local bindings_found=()
-    
+
     # Parse arguments - first determine where packages end and webapps begin
     local separator_index=-1
     for i in "${!installed_packages[@]}"; do
@@ -376,7 +429,7 @@ enhanced_select_packages() {
             break
         fi
     done
-    
+
     if [[ $separator_index -ge 0 ]]; then
         # Split into packages and webapps
         for ((i=0; i<separator_index; i++)); do
@@ -394,7 +447,7 @@ enhanced_select_packages() {
             item_types+=("package")
         done
     fi
-    
+
     # Build display items with type indicators and binding markers
     for i in "${!all_items[@]}"; do
         local prefix=""
@@ -403,7 +456,7 @@ enhanced_select_packages() {
         else
             prefix="📦 "
         fi
-        
+
         # Check if this item has keyboard bindings
         local item_bindings=$(find_app_bindings "${all_items[$i]}")
         if [[ -n "$item_bindings" ]]; then
@@ -414,13 +467,13 @@ enhanced_select_packages() {
             display_items+=("${prefix}${all_items[$i]}")
         fi
     done
-    
+
     # Check if any items have bindings
     local has_bindings=false
     for bf in "${bindings_found[@]}"; do
         [[ $bf -eq 1 ]] && has_bindings=true && break
     done
-    
+
     # Function to display the main interface header
     show_main_header() {
         # Show header with style
@@ -443,9 +496,9 @@ enhanced_select_packages() {
         gum style \
             --foreground 237 \
             "═════════════════════════════════════════════════"
-        
+
         echo ""
-        
+
         # Show item counts
         local pkg_count=0
         local webapp_count=0
@@ -456,34 +509,34 @@ enhanced_select_packages() {
                 ((webapp_count++))
             fi
         done
-        
+
         gum style \
             --foreground 214 \
             --bold \
             "Found $pkg_count packages and $webapp_count webapps"
-        
+
         echo ""
     }
-    
+
     # App selection interface - no keyboard toggle here anymore
     while true; do
         show_main_header
-        
+
         # Show help text for selection
         gum style \
             --foreground 51 \
             --italic \
             "Select items to remove (Tab to select, Enter to confirm)"
-        
+
         if [[ "$has_bindings" == true ]]; then
             gum style \
                 --foreground 39 \
                 --italic \
                 "(⌨ = has keyboard shortcuts - you'll be asked about cleanup next)"
         fi
-        
+
         echo ""
-        
+
         selected_items=$(printf '%s\n' "${display_items[@]}" | \
             gum filter \
                 --limit 0 \
@@ -494,12 +547,12 @@ enhanced_select_packages() {
                 --placeholder "Type to filter..." \
                 --header "Select items to remove:" \
                 --height 15)
-        
+
         # Check if user cancelled
         if [[ $? -ne 0 ]]; then
             return 1
         fi
-        
+
         # Check if no items selected
         if [[ -z "$selected_items" ]]; then
             echo ""
@@ -517,19 +570,19 @@ enhanced_select_packages() {
             # Continue loop to try again
             continue
         fi
-        
+
         # Valid selection made, break out of loop
         break
     done
-    
+
     # Parse selected items back to original names
     local selected_packages=()
     local selected_webapps=()
-    
+
     while IFS= read -r selected_item; do
         # Remove emoji prefix (📦 or 🌐) and keyboard marker (⌨)
         local clean_item=$(echo "$selected_item" | sed 's/^[📦🌐] //' | sed 's/ ⌨$//')
-        
+
         # Find matching item in original arrays
         for i in "${!all_items[@]}"; do
             if [[ "${all_items[$i]}" == "$clean_item" ]]; then
@@ -542,7 +595,7 @@ enhanced_select_packages() {
             fi
         done
     done <<< "$selected_items"
-    
+
     # Use newline-delimited strings to preserve items with spaces
     SELECTED_PACKAGES=$(printf '%s\n' "${selected_packages[@]}")
     SELECTED_WEBAPPS=$(printf '%s\n' "${selected_webapps[@]}")
@@ -554,27 +607,27 @@ remove_webapps() {
     local webapps=("$@")
     local failed_webapps=()
     local removed_webapps=()
-    
+
     if [[ ${#webapps[@]} -eq 0 ]]; then
         return 0
     fi
-    
+
     echo ""
     gum style \
         --foreground 39 \
         --bold \
         "🌐 Removing ${#webapps[@]} webapp(s)..."
     echo ""
-    
+
     local current=0
     local total=${#webapps[@]}
-    
+
     for webapp in "${webapps[@]}"; do
         ((current++))
-        
+
         # Show current progress
         gum style --foreground 51 "[$current/$total] Processing: $webapp"
-        
+
         if gum spin --spinner dot --title "Removing $webapp..." -- bash -c "omarchy-webapp-remove '$webapp' >/dev/null 2>&1"; then
             gum log --level info "✓ Removed: $webapp"
             removed_webapps+=("$webapp")
@@ -582,19 +635,19 @@ remove_webapps() {
             gum log --level error "✗ Failed: $webapp"
             failed_webapps+=("$webapp")
         fi
-        
+
         # Show progress bar
         local percentage=$(( (current * 100) / total ))
         local filled=$(( percentage / 5 ))
         local empty=$(( (100 - percentage) / 5 ))
-        
+
         printf "Progress: "
         printf '\033[92m█%.0s\033[0m' $(seq 1 $filled)
         printf '\033[90m░%.0s\033[0m' $(seq 1 $empty)
         printf " %d%% (%d/%d)\n" "$percentage" "$current" "$total"
         echo ""
     done
-    
+
     # Summary for webapps
     echo ""
     if [[ ${#removed_webapps[@]} -gt 0 ]]; then
@@ -613,11 +666,11 @@ remove_packages() {
     local packages=("$@")
     local failed_packages=()
     local removed_packages=()
-    
+
     if [[ ${#packages[@]} -eq 0 ]]; then
         return 0
     fi
-    
+
     echo ""
     gum style \
         --foreground 39 \
@@ -634,36 +687,72 @@ remove_packages() {
         fi
         echo ""
     fi
-    
+
     local current=0
     local total=${#packages[@]}
-    
+
     for pkg in "${packages[@]}"; do
         ((current++))
-        
+
         # Show current progress
         gum style --foreground 51 "[$current/$total] Processing: $pkg"
-        
-        if gum spin --spinner dot --title "Removing $pkg..." -- bash -c "sudo pacman -Rns --noconfirm '$pkg' 2>/dev/null"; then
+
+        # Try to remove the package, capturing output
+        local output
+        output=$(sudo pacman -Rns --noconfirm "$pkg" 2>&1)
+        local exit_code=$?
+
+        if [[ $exit_code -eq 0 ]]; then
             gum log --level info "✓ Removed: $pkg"
             removed_packages+=("$pkg")
         else
-            gum log --level warn "✗ Failed: $pkg (may have dependencies)"
-            failed_packages+=("$pkg")
+            # Removal failed
+            gum log --level warn "✗ Failed to remove '$pkg'."
+
+            # Show the error from pacman in a styled box
+            echo ""
+            gum style --border normal --padding "1 2" --margin "0 1" --border-foreground 214 "Pacman output:" "$output"
+            echo ""
+
+            gum style --bold "This is likely a dependency issue."
+            gum style "You can try to remove the package and all other packages that depend on it."
+            gum style --foreground 214 --italic "Warning: This could remove more than you expect. Review the list above carefully."
+            echo ""
+
+            if gum confirm "Attempt to remove '$pkg' AND its dependent packages?"; then
+                # User confirmed, try recursive remove
+                local recursive_output
+                recursive_output=$(sudo pacman -Rsc --noconfirm "$pkg" 2>&1)
+                local recursive_exit_code=$?
+                
+                if [[ $recursive_exit_code -eq 0 ]]; then
+                    gum log --level info "✓ Successfully removed '$pkg' and its dependencies."
+                    removed_packages+=("$pkg")
+                else
+                    # Even recursive removal failed, show final error
+                    gum log --level error "✗ Recursive removal of '$pkg' also failed."
+                    gum style --border normal --padding "1 2" --margin "0 1" --border-foreground 196 "Pacman output:" "$recursive_output"
+                    failed_packages+=("$pkg")
+                fi
+            else
+                # User declined
+                gum log --level info "Skipping '$pkg'."
+                failed_packages+=("$pkg")
+            fi
         fi
-        
+
         # Show progress bar
         local percentage=$(( (current * 100) / total ))
         local filled=$(( percentage / 5 ))
         local empty=$(( (100 - percentage) / 5 ))
-        
+
         printf "Progress: "
         printf '\033[92m█%.0s\033[0m' $(seq 1 $filled)
         printf '\033[90m░%.0s\033[0m' $(seq 1 $empty)
         printf " %d%% (%d/%d)\n" "$percentage" "$current" "$total"
         echo ""
     done
-    
+
     # Summary for packages
     echo ""
     if [[ ${#removed_packages[@]} -gt 0 ]]; then
@@ -686,7 +775,7 @@ remove_items() {
     # Global success tracking
     local total_attempted=0
     local total_failed=0
-    
+
     # Parse arguments - find separator
     local separator_index=-1
     for i in "${!packages[@]}"; do
@@ -695,24 +784,24 @@ remove_items() {
             break
         fi
     done
-    
+
     if [[ $separator_index -ge 0 ]]; then
         # Split into packages and webapps arrays
         local pkg_array=()
         local webapp_array=()
-        
+
         for ((i=0; i<separator_index; i++)); do
             pkg_array+=("${packages[$i]}")
         done
         for ((i=separator_index+1; i<${#packages[@]}; i++)); do
             webapp_array+=("${packages[$i]}")
         done
-        
+
         # Collect bindings to remove if enabled
         if [[ "$REMOVE_BINDINGS" == true ]]; then
             echo ""
             gum style --foreground 51 "Checking for keyboard shortcuts..."
-            
+
             for pkg in "${pkg_array[@]}"; do
                 local pkg_bindings=$(find_app_bindings "$pkg")
                 if [[ -n "$pkg_bindings" ]]; then
@@ -723,7 +812,7 @@ remove_items() {
                     done <<< "$pkg_bindings"
                 fi
             done
-            
+
             for webapp in "${webapp_array[@]}"; do
                 local webapp_bindings=$(find_app_bindings "$webapp")
                 if [[ -n "$webapp_bindings" ]]; then
@@ -734,7 +823,7 @@ remove_items() {
                     done <<< "$webapp_bindings"
                 fi
             done
-            
+
             # Remove bindings first
             if [[ ${#all_bindings_to_remove[@]} -gt 0 ]]; then
                 echo ""
@@ -745,7 +834,7 @@ remove_items() {
                 gum log --level info "No keyboard shortcuts found"
             fi
         fi
-        
+
         # Track package removal results
         total_attempted=$((${#pkg_array[@]} + ${#webapp_array[@]}))
 
@@ -770,7 +859,7 @@ remove_items() {
         if [[ "$REMOVE_BINDINGS" == true ]]; then
             echo ""
             gum style --foreground 51 "Checking for keyboard shortcuts..."
-            
+
             for pkg in "${packages[@]}"; do
                 local pkg_bindings=$(find_app_bindings "$pkg")
                 if [[ -n "$pkg_bindings" ]]; then
@@ -781,7 +870,7 @@ remove_items() {
                     done <<< "$pkg_bindings"
                 fi
             done
-            
+
             # Remove bindings first
             if [[ ${#all_bindings_to_remove[@]} -gt 0 ]]; then
                 echo ""
@@ -798,7 +887,7 @@ remove_items() {
         remove_packages "${packages[@]}"
         total_failed=$?
     fi
-    
+
     # Hero-style completion summary
     echo ""
     local successful_count=$((total_attempted - total_failed))
@@ -868,7 +957,7 @@ remove_items() {
 # Main function
 main() {
     clear
-    
+
     # Show ASCII logo
     gum style \
         --foreground 39 \
@@ -882,20 +971,20 @@ main() {
         "    / /___/ /  __/ /_/ / / / /  __/ /         " \
         "    \____/_/\___/\__,_/_/ /_/\___/_/          " \
         "                                              "
-    
+
     echo ""
-    
+
     # Show scanning message
     gum style --foreground 51 "🔍 Scanning for installed packages and webapps..."
     echo ""
-    
+
     # Show spinners while scanning (the actual functions are fast, so we add a small delay for visual feedback)
     gum spin --spinner globe --title "Checking packages..." -- sleep 0.8
     readarray -t installed_packages < <(get_installed_packages)
-    
+
     gum spin --spinner globe --title "Checking webapps..." -- sleep 0.8
     readarray -t installed_webapps < <(get_installed_webapps)
-    
+
     if [[ ${#installed_packages[@]} -eq 0 ]] && [[ ${#installed_webapps[@]} -eq 0 ]]; then
         echo ""
         gum style \
@@ -910,9 +999,9 @@ main() {
         echo ""
         exit 0
     fi
-    
+
     # Go directly to selection
-    
+
     # Combine packages and webapps with separator
     local all_items=()
     all_items+=("${installed_packages[@]}")
@@ -920,39 +1009,39 @@ main() {
         all_items+=("--webapps--")
         all_items+=("${installed_webapps[@]}")
     fi
-    
+
     # Use enhanced selection menu
     enhanced_select_packages "${all_items[@]}"
     local result=$?
-    
+
     if [[ $result -ne 0 ]]; then
         clear
         echo ""
         gum log --level info "Operation cancelled"
         exit 0
     fi
-    
+
     # The function will set global variables with selected items
     local selected_packages="$SELECTED_PACKAGES"
     local selected_webapps="$SELECTED_WEBAPPS"
-    
+
     # Convert to arrays properly - these are space-separated strings from the selection function
     local packages_array=()
     local webapps_array=()
-    
+
     # Parse newline-delimited strings into arrays
     if [[ -n "$selected_packages" ]]; then
         readarray -t packages_array <<< "$selected_packages"
     fi
-    
+
     if [[ -n "$selected_webapps" ]]; then
         readarray -t webapps_array <<< "$selected_webapps"
     fi
-    
+
     # Check if any selected items have keyboard shortcuts
     local selected_items_have_bindings=false
     local total_bindings=0
-    
+
     # Only check for bindings if the bindings file exists
     if [[ -f "$BINDINGS_FILE" ]]; then
         for pkg in "${packages_array[@]}"; do
@@ -962,7 +1051,7 @@ main() {
                 total_bindings=$((total_bindings + $(echo "$bindings" | wc -l)))
             fi
         done
-        
+
         for webapp in "${webapps_array[@]}"; do
             local bindings=$(find_app_bindings "$webapp")
             if [[ -n "$bindings" ]]; then
@@ -971,11 +1060,11 @@ main() {
             fi
         done
     fi
-    
+
     # Ask about keyboard shortcut cleanup if selected items have bindings
     if [[ "$selected_items_have_bindings" == true ]]; then
         clear
-        
+
         gum style \
             --border double \
             --border-foreground 51 \
@@ -983,16 +1072,16 @@ main() {
             --width 60 \
             --align center \
             "⌨  KEYBOARD SHORTCUTS DETECTED"
-        
+
         echo ""
-        
+
         gum style \
             --foreground 51 \
             --bold \
             "Found $total_bindings keyboard shortcut(s) for the selected items:"
-        
+
         echo ""
-        
+
         # Show items with bindings
         for pkg in "${packages_array[@]}"; do
             local bindings=$(find_app_bindings "$pkg")
@@ -1002,7 +1091,7 @@ main() {
                     "📦 $pkg"
             fi
         done
-        
+
         for webapp in "${webapps_array[@]}"; do
             local bindings=$(find_app_bindings "$webapp")
             if [[ -n "$bindings" ]]; then
@@ -1011,21 +1100,21 @@ main() {
                     "🌐 $webapp"
             fi
         done
-        
+
         echo ""
-        
+
         gum style \
             --foreground 51 \
             --italic \
             "Do you want to remove their keyboard shortcuts from ~/.config/hypr/bindings.conf?"
-        
+
         gum style \
             --foreground 240 \
             --italic \
             "(A backup will be created before making changes)"
-        
+
         echo ""
-        
+
         if gum confirm "Remove keyboard shortcuts?"; then
             REMOVE_BINDINGS=true
             gum style \
@@ -1037,7 +1126,7 @@ main() {
                 --foreground 214 \
                 "✓ Keyboard shortcuts will be kept"
         fi
-        
+
         echo ""
         gum style \
             --foreground 240 \
@@ -1045,7 +1134,7 @@ main() {
             "Press Enter to continue..."
         read </dev/tty
     fi
-    
+
     # Create combined array for removal function
     local items_to_remove=()
     items_to_remove+=("${packages_array[@]}")
@@ -1053,13 +1142,13 @@ main() {
         items_to_remove+=("--webapps--")
         items_to_remove+=("${webapps_array[@]}")
     fi
-    
+
     # Final confirmation
     clear
-    
+
     # Build confirmation content using separate lines
     local total_count=$((${#packages_array[@]} + ${#webapps_array[@]}))
-    
+
     # Show confirmation header
     gum style \
         --border double \
@@ -1072,22 +1161,22 @@ main() {
         --width 60 \
         --align center \
         "CONFIRMATION REQUIRED"
-    
+
     echo ""
-    
+
     gum style \
         --bold \
         "Ready to remove $total_count item(s):"
-    
+
     echo ""
-    
+
     # Show packages if any
     if [[ ${#packages_array[@]} -gt 0 ]]; then
         gum style \
             --foreground 39 \
             --bold \
             "📦 Packages (${#packages_array[@]}):"
-        
+
         for pkg in "${packages_array[@]}"; do
             gum style \
                 --foreground 214 \
@@ -1095,14 +1184,14 @@ main() {
         done
         echo ""
     fi
-    
+
     # Show webapps if any
     if [[ ${#webapps_array[@]} -gt 0 ]]; then
         gum style \
             --foreground 39 \
             --bold \
             "🌐 Webapps (${#webapps_array[@]}):"
-        
+
         for webapp in "${webapps_array[@]}"; do
             gum style \
                 --foreground 214 \
@@ -1110,7 +1199,7 @@ main() {
         done
         echo ""
     fi
-    
+
     # Show keyboard shortcuts info if applicable
     if [[ "$REMOVE_BINDINGS" == true ]]; then
         local total_bindings=0
@@ -1122,7 +1211,7 @@ main() {
             local bindings=$(find_app_bindings "$webapp")
             [[ -n "$bindings" ]] && total_bindings=$((total_bindings + $(echo "$bindings" | wc -l)))
         done
-        
+
         if [[ $total_bindings -gt 0 ]]; then
             gum style \
                 --foreground 51 \
@@ -1131,13 +1220,13 @@ main() {
             echo ""
         fi
     fi
-    
+
     echo ""
-    
+
     # Show confirmation prompt with integrated warning
     echo "Proceed with removal? $(gum style --foreground 240 --italic "(This action cannot be undone!)")"
     echo ""
-    
+
     if gum confirm; then
         clear
         remove_items "${items_to_remove[@]}"


### PR DESCRIPTION
## Summary
- Removed `gum` from the uninstall list to prevent accidental removal of a core dependency.
- Enhanced uninstall error handling: pacman errors are now displayed to inform the user of failure reasons.
- Added a presence check for `gum`; prompts the user to install if missing, with a safe fallback to prevent runtime errors.

## Motivation
This improves script stability and user experience by:
- Ensuring essential dependencies are preserved.
- Providing clear feedback when uninstall operations fail.
- Preventing crashes in interactive script components when `gum` is not installed.

## Testing
- Cleaner script tested with `gum` installed → normal operation.
- Tested uninstall of non-removable packages → pacman errors displayed correctly.
- Tested script with `gum` missing → user is prompted to install or fallback safely.
